### PR TITLE
appenders/tailers are (assumed to be) not threadsafe

### DIFF
--- a/test/qbits/tape_test.clj
+++ b/test/qbits/tape_test.clj
@@ -46,7 +46,7 @@
                        #(tailer/read! *tailer*))))))
 
 (deftest test-async-tailer
-  (let [tailer-ch (tape.async/tailer-chan *tailer*)
+  (let [tailer-ch (tape.async/tailer-chan *queue*)
         msgs (gen-msgs)]
 
     (run! #(appender/write! *appender* %)
@@ -57,7 +57,7 @@
                        #(async/<!! tailer-ch))))))
 
 (deftest test-async-appender
-  (let [appender-ch (tape.async/appender-chan *appender*)
+  (let [appender-ch (tape.async/appender-chan *queue*)
         msgs (gen-msgs)]
 
     (run! #(async/>!! appender-ch %)


### PR DESCRIPTION
Might be the source of corruption of the last message on disk.