### PR TITLE
tailer: New option to not call .rollbackOnClose when an exception occurs while reading

### DIFF
--- a/src/qbits/tape/tailer.clj
+++ b/src/qbits/tape/tailer.clj
@@ -54,7 +54,6 @@
                               java.nio.ByteBuffer/wrap
                               (codec/read codec)))
                        (catch Throwable t
-                         (.rollbackOnClose ctx)
                          t))]
              (when (instance? Throwable ret)
                (throw (ex-info "Tailer read failed"

--- a/src/qbits/tape/tailer.clj
+++ b/src/qbits/tape/tailer.clj
@@ -5,7 +5,8 @@
             [clojure.core.protocols :as p])
   (:import (net.openhft.chronicle.queue ChronicleQueue
                                         ExcerptTailer
-                                        TailerDirection)))
+                                        TailerDirection)
+           (java.nio ByteBuffer)))
 
 (set! *warn-on-reflection* true)
 
@@ -47,20 +48,17 @@
        ITailer
        (read! [_]
          (with-open [ctx (.readingDocument tailer)]
-           (let [ret (try
-                       (when (.isPresent ctx)
-                         (->> ctx
-                              .wire .read .bytes
-                              java.nio.ByteBuffer/wrap
-                              (codec/read codec)))
-                       (catch Throwable t
-                         t))]
-             (when (instance? Throwable ret)
+           (try
+             (when (.isPresent ctx)
+               (->> ctx
+                    .wire .read .bytes
+                    (ByteBuffer/wrap)
+                    (codec/read codec)))
+             (catch Throwable t
                (throw (ex-info "Tailer read failed"
                                {:type ::read-failed
                                 :tailer tailer}
-                               ret)))
-             ret)))
+                               t))))))
 
        (set-direction! [_ direction]
          (.direction tailer (->tailer-direction direction)))


### PR DESCRIPTION
While checking for a way to just bypass the current message when the current message throws an Underflow exception, I found something interesting: When an exception occurs in the tailer read, the exception is passed into the channel and `.rollbackOnClose` is called. However in the documentation they only mention it for writing https://github.com/OpenHFT/Chronicle-Queue#exceptions-thrown-with-a-writingdocument . By looking at the code, it is called in the appender.

Questions: (1) Why would we want to call this in the tailer? Could it be related to our issue of underflow because `.rollbackOnClose` probably write something so it may not help. Also we may want to skip the message anyway. (2) Would that change help?