### PR TITLE
Bump dependencies

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -3,11 +3,11 @@
  :deps {org.clojure/clojure {:mvn/version "1.10.1"}
         org.clojure/core.async {:mvn/version "1.3.610"}
         org.clojure/tools.logging {:mvn/version "1.1.0"}
-        net.openhft/chronicle-queue {:mvn/version "5.20.122"}
+        net.openhft/chronicle-queue {:mvn/version "5.21ea8"}
         cc.qbits/commons {:mvn/version "1.0.0-alpha3"}
         org.clojure/data.fressian {:mvn/version "1.0.0"}
         org.clojure/test.check {:mvn/version "1.0.0"}
-        net.openhft/chronicle-bytes {:mvn/version "2.20.111"}}
+        net.openhft/chronicle-bytes {:mvn/version "2.21ea12"}}
 
  :aliases
  {:test {:extra-deps {lambdaisland/kaocha {:mvn/version "0.0-305"}


### PR DESCRIPTION
Bump shronicle-queue and chronicle-bytes to the latest versions.

tests seems unstable, I ran them several times and one run failed:

```
lein test :only qbits.tape-test/test-seq

FAIL in (test-seq) (tape_test.clj:126)
expected: (= (seq msgs) (seq *tailer*))
  actual: (not (= ({} {1/2 v!} {1 bT} {} {:*/+V? :V+, :__/O!_ #uuid "c655a66f-611a-4db0-b881-c86182226d82"} {\) false, -0.6875 :k.+/KDp} {Q9w :-p9} {} #:PFMq{:j69 #uuid "508da67d-4a43-4669-83f2-26db3277315d"} {#uuid "e1d15784-5bcd-464d-81a3-38945b3d63bb" ##NaN, x-*/D+kN -988251385991265N, -7/8 #uuid "513b51af-d3d4-46ee-919c-dee6783c0619", -1120N 12N, \4 #uuid "ee0a3f90-fa13-45cf-bd5e-57e5d8fca693", 2 "p", false 8, 4714453764165N true, yej_/qMx -74N}) ({} {1/2 v!} {1 bT} {} {:*/+V? :V+, :__/O!_ #uuid "c655a66f-611a-4db0-b881-c86182226d82"} {\) false, -0.6875 :k.+/KDp} {Q9w :-p9} {} #:PFMq{:j69 #uuid "508da67d-4a43-4669-83f2-26db3277315d"} {#uuid "e1d15784-5bcd-464d-81a3-38945b3d63bb" ##NaN, x-*/D+kN -988251385991265N, -7/8 #uuid "513b51af-d3d4-46ee-919c-dee6783c0619", -1120N 12N, \4 #uuid "ee0a3f90-fa13-45cf-bd5e-57e5d8fca693", 2 "p", false 8, 4714453764165N true, yej_/qMx -74N})))

Ran 9 tests containing 9 assertions.
1 failures, 0 errors.
Tests failed.
```

I don't know if it's related to the deps bump.