### PR TITLE
Optionally create restartable tailers.

### DIFF
--- a/src/qbits/tape/tailer.clj
+++ b/src/qbits/tape/tailer.clj
@@ -28,6 +28,7 @@
   `poll-interval` will set the wait interval the tailer will apply
   when used in a reducible or seq context only when there are no new
   message ready to be consumed.
+  `tailer-id` can be passed for restartable tailers.
 
   clojure.datafy/datafy can be called on the tailer to get associated data
 
@@ -40,9 +41,13 @@
   https://github.com/OpenHFT/Chronicle-Queue#how-does-chronicle-queue-work"
   ([queue]
    (make queue nil))
-  ([queue {:keys [poll-interval]
+  ([queue {:keys [poll-interval
+                  tailer-id]
            :or {poll-interval 50}}]
-   (let [^ExcerptTailer tailer (.createTailer (q/underlying-queue queue))
+   (let [^ExcerptTailer tailer
+         (if tailer-id
+           (.createTailer (q/underlying-queue queue) tailer-id)
+           (.createTailer (q/underlying-queue queue)))
          codec (q/codec queue)]
      (reify
        ITailer


### PR DESCRIPTION
Chronicle Queue allows the creation of tailers that can [restart from their last position](https://github.com/OpenHFT/Chronicle-Queue#restartable-tailers).

This PR provides an extra option, `:tailer-id` for `qbits.tape.tailer/make`. This allows a restartable tailer to be created like this: `(tailer/make q {:tailer-id "a"})`.